### PR TITLE
Make _process_verbose_param(::Bool) constprop-friendly to fix @inferred solve

### DIFF
--- a/lib/DiffEqBase/src/verbosity.jl
+++ b/lib/DiffEqBase/src/verbosity.jl
@@ -340,7 +340,10 @@ const NONE_VERBOSE = DEVerbosity(SciMLLogging.None())
     return DEVerbosity(verbose)
 end
 
-@inline function _process_verbose_param(verbose::Bool)
+@inline _process_verbose_param(::Val{true}) = DEFAULT_VERBOSE
+@inline _process_verbose_param(::Val{false}) = NONE_VERBOSE
+
+Base.@constprop :aggressive @inline function _process_verbose_param(verbose::Bool)
     return verbose ? DEFAULT_VERBOSE : NONE_VERBOSE
 end
 

--- a/lib/DiffEqBase/test/runtests.jl
+++ b/lib/DiffEqBase/test/runtests.jl
@@ -46,6 +46,7 @@ end
         @time @safetestset "DynamicQuantities extension" include("dynamicquantities_ext.jl")
         @time @safetestset "ODE default unstable check" include("ode_default_unstable_check.jl")
         @time @safetestset "Problem Kwargs Merging" include("problem_kwargs_merging.jl")
+        @time @safetestset "Verbose Inference" include("verbose_inference.jl")
     end
 
     # QA tests — Aqua quality checks

--- a/lib/DiffEqBase/test/verbose_inference.jl
+++ b/lib/DiffEqBase/test/verbose_inference.jl
@@ -1,0 +1,19 @@
+using DiffEqBase, Test
+
+# Verify that the Bool path of `_process_verbose_param` is type-stable when
+# the Bool is a compile-time literal (the default `verbose = true` case from
+# `solve`/`init`). Without `Base.@constprop :aggressive`, both branches return
+# different concrete `DEVerbosity{...}` parameterizations and the result is a
+# `Union{...}` that poisons inference all the way through `solve`.
+
+@testset "_process_verbose_param inference" begin
+    # Val-dispatch is unconditionally type-stable.
+    @inferred DiffEqBase._process_verbose_param(Val(true))
+    @inferred DiffEqBase._process_verbose_param(Val(false))
+
+    # Constprop on literal Bool resolves to a single concrete type.
+    f_true() = DiffEqBase._process_verbose_param(true)
+    f_false() = DiffEqBase._process_verbose_param(false)
+    @test Base.return_types(f_true, ())[1] === typeof(DiffEqBase.DEFAULT_VERBOSE)
+    @test Base.return_types(f_false, ())[1] === typeof(DiffEqBase.NONE_VERBOSE)
+end


### PR DESCRIPTION
Stacked on top of SciML/OrdinaryDiffEq.jl#3365 (targeting your `move_verbosity` branch directly so it merges in cleanly).

## Summary
- `DEFAULT_VERBOSE` and `NONE_VERBOSE` are different concrete parameterizations of `DEVerbosity{...}` (different `Silent`/`WarnLevel`/`InfoLevel` type parameters per toggle), so the ternary `verbose ? DEFAULT_VERBOSE : NONE_VERBOSE` returns a `Union{...}` whenever `verbose::Bool` isn't a compile-time constant.
- That `Union` flows into the solver caches — you can see `LinearVerbosity{Silent,Silent,...,WarnLevel,WarnLevel,...}` baked into the `LinearCache` type in #3365's CI failure logs — and it poisons return-type inference all the way to `ODESolution`. Tests like `@inferred solve(prob_mm, Rodas5P(), ...)` in `lib/OrdinaryDiffEqRosenbrock/test/dae_rosenbrock_ad_tests.jl` fail with `does not match inferred return type Any`.
- This PR annotates the `Bool` method with `Base.@constprop :aggressive` so the compiler threads the literal default `verbose = true` through the kwargs chain to a single concrete `DEVerbosity` parameterization.
- Adds `Val{true}`/`Val{false}` overloads as an explicit type-stable entry point for callers that don't want to rely on constprop reaching them.

The runtime-`Bool`-with-no-constprop case still returns a `Union`; that's an inherent property of the `@verbosity_specifier` design (verbosity levels are encoded as type parameters). The proper fix for that case is to keep verbosity out of the cache type parameters, but this is the smallest change that unblocks #3365's `@inferred` tests.

## Test plan
- [x] New `lib/DiffEqBase/test/verbose_inference.jl` exercises both the `Val`-dispatch path (unconditionally inferable) and the literal-`Bool` constprop path (verifies `Base.return_types` resolves to a single concrete type).
- [x] Runic clean.
- [ ] Re-run the Rosenbrock / DiffEqDevTools / Integrators test groups that were failing on #3365 with `@inferred solve(...)` errors.